### PR TITLE
Automatically convert 3rd argument of print() to a string.

### DIFF
--- a/src/js/vm_worker.js
+++ b/src/js/vm_worker.js
@@ -192,6 +192,8 @@ function rcn_vm_worker_function(rcn) {
     x -= cam_x();
     y -= cam_y();
 
+    text = String(text);
+
     const ox = x;
 
     for(let i = 0; i < text.length; i++) {


### PR DESCRIPTION
It makes sense to allow “print(x, y, 1234);” instead of failing silently.